### PR TITLE
Dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyswap"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python wrapper for SWAP hydrological model."
 authors = ["Mateusz <zawadzkimat@outlook.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyswap"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python wrapper for SWAP hydrological model."
 authors = ["Mateusz <zawadzkimat@outlook.com>"]
 license = "MIT"

--- a/pyswap/atmosphere/meteorology.py
+++ b/pyswap/atmosphere/meteorology.py
@@ -115,7 +115,8 @@ class Meteorology(PySWAPBaseModel):
             path (str): Path to the file.
         """
         save_file(
-            string=self.metfile.content.to_csv(index=False),
+            string=self.metfile.content.to_csv(
+                index=False, lineterminator='\n'),
             fname=self.metfile.metfil,
             path=path
         )


### PR DESCRIPTION
On windows, the met file was getting an additional empty line inbetween the records. That is because of the line terminator on Windows which is '\r\n'. Replaced it to just '\n'