### PR TITLE
feat: add __version__ attribute to pyswap package

### DIFF
--- a/pyswap/__init__.py
+++ b/pyswap/__init__.py
@@ -8,6 +8,10 @@ from pyswap.log import _setup_logger, set_log_level
 from pyswap.model.model import Model, run_parallel
 from pyswap.utils.loaders import load_bbc, load_crp, load_dra, load_swp
 
+# Version information
+import importlib.metadata
+__version__ = importlib.metadata.version("pyswap")
+
 __all__ = [
     "components",
     "gis",


### PR DESCRIPTION
- Add __version__ attribute using importlib.metadata for modern Python compatibility
- Follows PEP 396 and PEP 621 best practices for version information
- Automatically syncs with version defined in pyproject.toml
- Improves package usability and follows Python community standards