### PR TITLE
fix: Tests should pass again

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -52,7 +52,7 @@
 *.ps1             text eol=crlf
 *.py              text diff=python
 *.rb              text diff=ruby
-*.RC              text
+*.R               text
 *.sass            text
 *.scm             text
 *.scss            text diff=css

--- a/pyswap/components/tables.py
+++ b/pyswap/components/tables.py
@@ -140,13 +140,13 @@ class CFTB(BaseTableModel):
 
     Attributes:
         DVS (Series[float]): Development stage of the crop.
+        DNR (Series[float]): Day number.
         CF (Series[float]): Crop factor.
     """
 
     DVS: Series[float] | None = pa.Field(**DVSRANGE)
     DNR: Series[float] | None = pa.Field(**YEARRANGE)
     CF: Series[float] | None
-    CH: Series[float] | None
 
 
 class CHTB(BaseTableModel):
@@ -154,13 +154,16 @@ class CHTB(BaseTableModel):
 
     Attributes:
         DVS (Series[float]): Development stage of the crop.
-        CF (Series[float]): Crop height.
+        DNR (Series[float]): Day number.
+        CH (Series[float]): Crop height.
     """
 
     DVS: Series[float] | None = pa.Field(**DVSRANGE)
     DNR: Series[float] | None = pa.Field(**YEARRANGE)
+    CF: (
+        Series[float] | None
+    )  # Added for compatibility with example grass files in original SWAP distribution that are used for testing this package. CF is only stated but not used there.
     CH: Series[float] | None
-    CF: Series[float] | None
 
 
 class INTERTB(BaseTableModel):

--- a/pyswap/testcase/hupselbrook.py
+++ b/pyswap/testcase/hupselbrook.py
@@ -87,7 +87,7 @@ def _make_hupselbrook():
         "LAI": [0.05, 0.14, 0.61, 4.10, 5.00, 5.80, 5.20],
     })
 
-    maize_cftb = psp.components.crop.CFTB.create({
+    maize_chtb = psp.components.crop.CHTB.create({
         "DVS": DVS,
         "CH": [1.0, 15.0, 40.0, 140.0, 170.0, 180.0, 175.0],
     })
@@ -110,7 +110,7 @@ def _make_hupselbrook():
         swgc=1,
         gctb=maize_gctb,
         swcf=2,
-        cftb=maize_cftb,
+        chtb=maize_chtb,
         albedo=0.23,
         rsc=61.0,
         rsw=0.0,
@@ -239,7 +239,7 @@ def _make_hupselbrook():
     )
 
     # %% Grass crp file
-    grass_cftb = psp.components.crop.CFTB.create({
+    grass_chtb = psp.components.crop.CHTB.create({
         "DNR": [0.0, 180.0, 366.0],
         "CH": [12.0, 12.0, 12.0],
     })
@@ -305,7 +305,7 @@ def _make_hupselbrook():
 
     grass_settings = psp.components.crop.CropDevelopmentSettingsGrass(
         swcf=2,
-        cftb=grass_cftb,
+        chtb=grass_chtb,
         albedo=0.23,
         rsc=100.0,
         rsw=0.0,

--- a/pyswap/testcase/simple_test_model.py
+++ b/pyswap/testcase/simple_test_model.py
@@ -150,7 +150,7 @@ def _make_simple_test_model():
     dvs = [0.0, 0.3, 0.5, 0.7, 1.0, 1.4, 2.0]
 
     ## Crop height
-    maize_chtb = psp.components.crop.CFTB.create({
+    maize_chtb = psp.components.crop.CHTB.create({
         "DVS": dvs,
         "CH": [1.0, 15.0, 40.0, 140.0, 170.0, 180.0, 175.0],
     })
@@ -196,9 +196,7 @@ def _make_simple_test_model():
     maize_cropdev_settings.update_from_wofost()
 
     ## Test update function -> validation is triggered
-    maize_cropdev_settings = maize_cropdev_settings.update({
-        "RSC": 0.0
-    })
+    maize_cropdev_settings = maize_cropdev_settings.update({"RSC": 0.0})
 
     ## Oxygen stress
     maize_ox_stress = psp.components.crop.OxygenStress(


### PR DESCRIPTION
Issue was because the validation.yaml was changed, a cftb was not allowed when swcf=2, which was the case when importing old swap files for grass for testing. Solution was to have CFTB only have the CF column, and CHTB both CH and CF columns. In this way reading the old SWAP files would return a CHTB instead of a CFTB. Then the validation doesnt give an error anymore.